### PR TITLE
Potential fix for code scanning alert no. 43: Database query built from user-controlled sources

### DIFF
--- a/controllers/APIController.js
+++ b/controllers/APIController.js
@@ -133,9 +133,9 @@ exports.APIGetSquaks = async (req, res) => {
 		var squaks;
 		if (req.query.author && req.query.author.match(/^[0-9a-fA-F]{24}$/)) {
 			squaks = await Tweet.find({
-				author: req.query.author
+				author: { $eq: req.query.author }
 			}).populate('author')
-			.sort({[req.query.sort || 'created']: req.query.order || 'desc'})
+			.sort({[req.query.sort && !notAuthorized.includes(req.query.sort) ? req.query.sort : 'created']: req.query.order === 'asc' || req.query.order === 'desc' ? req.query.order : 'desc'})
 			.limit(to);
 		} else if (req.query.author) {
 			return res.json({

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -463,7 +463,7 @@ exports.verifyRegister = async (req, res, next) => {
 
 exports.checkUserExists = async (req, res, next) => {
 	var user = await User.find({
-		username: req.body.username
+		username: { $eq: req.body.username }
 	})
 
 	if (user.length) {
@@ -472,7 +472,7 @@ exports.checkUserExists = async (req, res, next) => {
 	}
 
 	user = await User.find({
-		email: req.body.email
+		email: { $eq: req.body.email }
 	})
 
 	if (user.length) {


### PR DESCRIPTION
Potential fix for [https://github.com/Nathn/Squakr/security/code-scanning/43](https://github.com/Nathn/Squakr/security/code-scanning/43)

To fix the problem, we need to ensure that the user input is safely embedded into the query. For MongoDB queries, we can use the `$eq` operator to ensure that the user input is interpreted as a literal value. This will prevent any potential NoSQL injection attacks.

We will modify the query on line 135 to use the `$eq` operator for the `author` field. Additionally, we will ensure that the `sort` and `order` parameters are validated to prevent any potential injection through these fields.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
